### PR TITLE
Add V6 data layer generators and QC tooling

### DIFF
--- a/preprocessing/gen_sessions.py
+++ b/preprocessing/gen_sessions.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Generate trading sessions calendar."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable, Set
+
+import pandas as pd
+
+try:  # Python 3.9+
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - fallback
+    from backports.zoneinfo import ZoneInfo  # type: ignore
+
+
+ASIA_END = 8  # 00:00-07:59
+EU_END = 16   # 08:00-15:59
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate a sessions.csv file.")
+    parser.add_argument("start", help="Start datetime (e.g. 2023-01-01 or 2023-01-01T00:00:00)")
+    parser.add_argument("end", help="End datetime inclusive (same format as start)")
+    parser.add_argument("timezone", help="Exchange timezone, e.g. UTC or Asia/Shanghai")
+    parser.add_argument(
+        "--holidays",
+        help="Optional path to a holiday calendar file (csv/json/txt) containing dates to exclude.",
+    )
+    parser.add_argument(
+        "--output",
+        default="data/meta/sessions.csv",
+        help="Where to save the generated CSV (default: data/meta/sessions.csv)",
+    )
+    return parser.parse_args()
+
+
+def _ensure_timezone(ts: pd.Timestamp, tz: ZoneInfo) -> pd.Timestamp:
+    if ts.tzinfo is None:
+        return ts.tz_localize(tz)
+    return ts.tz_convert(tz)
+
+
+def _load_holidays(path: Path) -> Set[pd.Timestamp]:
+    if not path.exists():
+        raise FileNotFoundError(f"Holiday file not found: {path}")
+
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        data = json.loads(path.read_text())
+        if isinstance(data, dict):
+            dates = data.values()
+        else:
+            dates = data
+        holiday_dates = {pd.to_datetime(d).normalize() for d in dates}
+    elif suffix in {".csv", ".txt", ".dat"}:
+        df = pd.read_csv(path)
+        if df.empty:
+            return set()
+        if "date" in df.columns:
+            dates_iter: Iterable = df["date"].tolist()
+        else:
+            dates_iter = df.iloc[:, 0].tolist()
+        holiday_dates = {pd.to_datetime(d).normalize() for d in dates_iter}
+    else:  # generic fallback
+        dates_iter = [line.strip() for line in path.read_text().splitlines() if line.strip()]
+        holiday_dates = {pd.to_datetime(d).normalize() for d in dates_iter}
+    return holiday_dates
+
+
+def _label_session(ts_utc: pd.Timestamp, tz: ZoneInfo) -> str:
+    ts_local = ts_utc.tz_convert(tz)
+    hour = ts_local.hour
+    if hour < ASIA_END:
+        return "asia"
+    if hour < EU_END:
+        return "eu"
+    return "us"
+
+
+def main() -> None:
+    args = _parse_args()
+    tz = ZoneInfo(args.timezone)
+
+    start_ts = pd.Timestamp(args.start)
+    end_ts = pd.Timestamp(args.end)
+    if end_ts < start_ts:
+        raise ValueError("End datetime must be after start datetime")
+
+    start_local = _ensure_timezone(start_ts, tz)
+    end_local = _ensure_timezone(end_ts, tz)
+
+    idx = pd.date_range(start=start_local.tz_convert("UTC"), end=end_local.tz_convert("UTC"), freq="T")
+
+    holidays: Set[pd.Timestamp] = set()
+    if args.holidays:
+        holidays = _load_holidays(Path(args.holidays))
+
+    df = pd.DataFrame(index=idx)
+    df.index.name = "timestamp"
+
+    if holidays:
+        local_index = df.index.tz_convert(tz)
+        mask = ~local_index.normalize().isin(holidays)
+        df = df.loc[mask]
+
+    df["session_id"] = [
+        _label_session(ts_utc, tz) for ts_utc in df.index
+    ]
+
+    df.reset_index(inplace=True)
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(output_path, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/preprocessing/merge_to_features.py
+++ b/preprocessing/merge_to_features.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Merge ATAS order-flow data with exchange klines to build a feature set."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable, List
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+DEFAULT_ATAS_DIR = Path("data/atas")
+DEFAULT_KLINE_PATH = Path("data/exchange/kline_1m.parquet")
+DEFAULT_OUTPUT_PATH = Path("data/processed/features.parquet")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Merge ATAS and exchange data into features.parquet")
+    parser.add_argument("--atas-dir", type=Path, default=DEFAULT_ATAS_DIR, help="Directory containing ATAS json files")
+    parser.add_argument("--kline", type=Path, default=DEFAULT_KLINE_PATH, help="Path to 1m kline parquet file")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT_PATH, help="Path to output parquet file")
+    return parser.parse_args()
+
+
+def _detect_timestamp_column(columns: Iterable[str]) -> str:
+    for candidate in ("timestamp", "time", "datetime", "ts"):
+        if candidate in columns:
+            return candidate
+    raise ValueError("No timestamp column found in ATAS file")
+
+
+def _load_single_json(path: Path) -> pd.DataFrame:
+    raw = path.read_text()
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        # fallback to pandas json reader for newline-delimited or other formats
+        return pd.read_json(path, lines=True)
+
+    if isinstance(data, dict):
+        if "data" in data and isinstance(data["data"], list):
+            df = pd.DataFrame(data["data"])
+        else:
+            df = pd.DataFrame([data])
+    else:
+        df = pd.DataFrame(data)
+    if df.empty:
+        return df
+    ts_col = _detect_timestamp_column(df.columns)
+    df[ts_col] = pd.to_datetime(df[ts_col], utc=True, errors="coerce")
+    df = df.dropna(subset=[ts_col])
+    df.rename(columns={ts_col: "timestamp"}, inplace=True)
+    df["timestamp"] = df["timestamp"].dt.floor("T")
+    keep_cols = [c for c in df.columns if c in {"timestamp", "MSI", "MFI", "KLI"}]
+    return df[keep_cols]
+
+
+def _load_atas(directory: Path) -> pd.DataFrame:
+    frames: List[pd.DataFrame] = []
+    if not directory.exists():
+        raise FileNotFoundError(f"ATAS directory not found: {directory}")
+    for path in sorted(directory.glob("*.json")):
+        df = _load_single_json(path)
+        if not df.empty:
+            frames.append(df)
+    if not frames:
+        raise ValueError(f"No ATAS json files with data found in {directory}")
+    merged = pd.concat(frames, ignore_index=True)
+    merged = merged.sort_values("timestamp").drop_duplicates(subset="timestamp", keep="last")
+    merged.set_index("timestamp", inplace=True)
+    return merged
+
+
+def _load_kline(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise FileNotFoundError(f"Kline parquet not found: {path}")
+    df = pd.read_parquet(path)
+    if "timestamp" not in df.columns:
+        raise ValueError("Kline parquet must contain a 'timestamp' column")
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce").dt.floor("T")
+    df = df.dropna(subset=["timestamp"]).drop_duplicates(subset="timestamp", keep="last")
+    df = df.sort_values("timestamp").set_index("timestamp")
+    if df["close"].isna().any():
+        raise ValueError("Found missing close prices in kline data")
+    return df
+
+
+def _build_features(kline: pd.DataFrame, atas: pd.DataFrame) -> pd.DataFrame:
+    merged = kline.join(atas, how="left")
+    merged.sort_index(inplace=True)
+
+    metrics_cols = [c for c in ["MSI", "MFI", "KLI"] if c in merged.columns]
+    if metrics_cols:
+        merged[metrics_cols] = merged[metrics_cols].ffill().fillna(0.0)
+
+    if "close" not in merged.columns:
+        raise ValueError("Kline data must contain a 'close' column to compute returns")
+
+    if merged["close"].isna().any():
+        raise ValueError("Missing close prices detected after merge")
+
+    safe_close = merged["close"].replace(0, np.nan)
+    merged["return_1m"] = merged["close"].pct_change().fillna(0.0)
+    merged["log_return_1m"] = np.log(safe_close).diff().replace([np.inf, -np.inf], 0.0).fillna(0.0)
+
+    if "volume" in merged.columns:
+        merged["volume_volatility_30m"] = (
+            merged["volume"].rolling(window=30, min_periods=1).std().fillna(0.0)
+        )
+        merged["volume_mean_30m"] = merged["volume"].rolling(window=30, min_periods=1).mean().fillna(0.0)
+    else:
+        merged["volume_volatility_30m"] = 0.0
+        merged["volume_mean_30m"] = 0.0
+
+    if {"MSI", "MFI"}.issubset(merged.columns):
+        merged["order_imbalance"] = (merged["MSI"] - merged["MFI"]).fillna(0.0)
+    else:
+        merged["order_imbalance"] = 0.0
+
+    numeric_cols = merged.select_dtypes(include=["number"]).columns
+    merged[numeric_cols] = merged[numeric_cols].fillna(0.0)
+
+    merged.reset_index(inplace=True)
+    merged.rename(columns={"index": "timestamp"}, inplace=True)
+    return merged
+
+
+def main() -> None:
+    args = _parse_args()
+
+    atas_df = _load_atas(args.atas_dir)
+    kline_df = _load_kline(args.kline)
+    features = _build_features(kline_df, atas_df)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    table = pa.Table.from_pandas(features)
+    pq.write_table(table, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/configs/costs.yaml
+++ b/validation/configs/costs.yaml
@@ -1,0 +1,12 @@
+base:
+  fee_rate: 0.0004
+  spread_bps: 5
+  slippage_bps: 5
+plus50:
+  fee_rate: 0.0006
+  spread_bps: 8
+  slippage_bps: 8
+double:
+  fee_rate: 0.0008
+  spread_bps: 10
+  slippage_bps: 10

--- a/validation/src/qc_report.py
+++ b/validation/src/qc_report.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Generate a markdown quality-control report for processed feature data."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+
+
+DEFAULT_FEATURES_PATH = Path("data/processed/features.parquet")
+DEFAULT_REPORT_PATH = Path("results/data_qc_report.md")
+EXPECTED_FREQ = pd.Timedelta(minutes=1)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate QC report for features.parquet")
+    parser.add_argument("--input", type=Path, default=DEFAULT_FEATURES_PATH, help="Path to features parquet file")
+    parser.add_argument("--output", type=Path, default=DEFAULT_REPORT_PATH, help="Output markdown report path")
+    return parser.parse_args()
+
+
+def _load_features(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise FileNotFoundError(f"Features parquet not found: {path}")
+    df = pd.read_parquet(path)
+    if "timestamp" not in df.columns:
+        raise ValueError("Features parquet must include a 'timestamp' column")
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
+    df = df.sort_values("timestamp").reset_index(drop=True)
+    return df
+
+
+def _missing_stats(df: pd.DataFrame) -> pd.DataFrame:
+    missing_pct = df.isna().mean() * 100
+    return missing_pct.to_frame(name="missing_pct").round(4)
+
+
+def _outlier_stats(df: pd.DataFrame) -> pd.DataFrame:
+    numeric_cols = df.select_dtypes(include=["number"]).columns
+    rows: List[dict] = []
+    for col in numeric_cols:
+        series = df[col].dropna()
+        if series.empty:
+            rows.append({"feature": col, "count": 0})
+            continue
+        mean = series.mean()
+        std = series.std(ddof=0)
+        if std == 0:
+            rows.append({"feature": col, "count": 0})
+            continue
+        mask = (series > mean + 3 * std) | (series < mean - 3 * std)
+        rows.append({"feature": col, "count": int(mask.sum())})
+    return pd.DataFrame(rows)
+
+
+def _time_jump_stats(df: pd.DataFrame) -> pd.DataFrame:
+    timestamps = df["timestamp"].dropna().sort_values()
+    diffs = timestamps.diff().dropna()
+    jumps = diffs[diffs > EXPECTED_FREQ]
+    if jumps.empty:
+        return pd.DataFrame([[0, 0]], columns=["jump_events", "missing_minutes"])
+    missing_minutes = (jumps / EXPECTED_FREQ - 1).round().astype(int)
+    return pd.DataFrame([[len(jumps), int(missing_minutes.sum())]], columns=["jump_events", "missing_minutes"])
+
+
+def _duplicate_stats(df: pd.DataFrame) -> pd.DataFrame:
+    duplicate_rows = int(df.duplicated().sum())
+    duplicate_timestamps = int(df["timestamp"].duplicated().sum())
+    return pd.DataFrame(
+        [[duplicate_rows, duplicate_timestamps]],
+        columns=["duplicate_rows", "duplicate_timestamps"],
+    )
+
+
+def main() -> None:
+    args = _parse_args()
+    df = _load_features(args.input)
+
+    missing_df = _missing_stats(df)
+    outlier_df = _outlier_stats(df)
+    jumps_df = _time_jump_stats(df)
+    duplicate_df = _duplicate_stats(df)
+
+    report_lines: List[str] = ["# Data Quality Report", ""]
+
+    report_lines.extend(["## Missing Values", missing_df.to_markdown(), ""])
+    report_lines.extend(["## 3σ Outliers", outlier_df.to_markdown(index=False), ""])
+    report_lines.extend(["## Time Continuity", jumps_df.to_markdown(index=False), ""])
+    report_lines.extend(["## Duplicate Checks", duplicate_df.to_markdown(index=False), ""])
+
+    output_path = args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(report_lines))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add configurable cost presets for validation runs
- implement session calendar generator with holiday exclusions
- create data pipeline to merge ATAS and kline data and produce QC report

## Testing
- python -m compileall preprocessing/gen_sessions.py preprocessing/merge_to_features.py validation/src/qc_report.py

------
https://chatgpt.com/codex/tasks/task_e_68dd212c03b0832fbdd43746eb90ca45